### PR TITLE
Handle Routing for Navbar

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.10.0",
         "react-scripts": "5.0.1"
       }
     },
@@ -3085,6 +3086,14 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.5.0.tgz",
+      "integrity": "sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -13714,6 +13723,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.10.0.tgz",
+      "integrity": "sha512-Nrg0BWpQqrC3ZFFkyewrflCud9dio9ME3ojHCF/WLsprJVzkq3q3UeEhMCAW1dobjeGbWgjNn/PVF6m46ANxXQ==",
+      "dependencies": {
+        "@remix-run/router": "1.5.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.10.0.tgz",
+      "integrity": "sha512-E5dfxRPuXKJqzwSe/qGcqdwa18QiWC6f3H3cWXM24qj4N0/beCIf/CWTipop2xm7mR0RCS99NnaqPNjHtrAzCg==",
+      "dependencies": {
+        "@remix-run/router": "1.5.0",
+        "react-router": "6.10.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -15473,19 +15512,6 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.10.0",
     "react-scripts": "5.0.1"
   },
   "scripts": {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,143 +1,28 @@
-import React from "react";
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+} from "react-router-dom";
+
+import Layout from "./Layout";
+import Blog from "./pages/Blog";
+import About from "./pages/About";
+import Post from "./pages/Post";
+import Metrics from "./pages/Metrics";
 
 function App() {
   return (
-    <div className="App">
-      <nav id="nav-bar">
-        <h1><span>&gt; Onyx Sal Blog</span></h1>
-        <ul>
-          <li>Blog</li>
-          <li>About</li>
-          <li>Post</li>
-          <li>Metrics</li>
-        </ul>
-      </nav>
-      {/* This holds the section and aside in one container  */}
-      <div id="section-and-aside">
-        {/* this sections holds our blog poast with everything inside of it 
-            <span> is what changes the font color
-        */}
-        {/* blog-id-1 */}
-        <section>
-          <h1 id="blog-id-1">This is the first post for the onyx crew</h1>
-          <h3>March 31st 2023 | <span>onyx spring</span></h3>
-          <p>Once upon a time, in a faraway land, there were seven travelers who set out on a quest to meet the powerful enchanter named Blog. These seven travelers were named Bruinbrewinbeer, DKKKKKKKK, iSonic, Jc, Julian_P, Nathanjs the King, and Stephenodea54.
-            The travelers had heard tales of Blog's incredible powers of enchantment and his minions, React, JavaScript, and TypeScript, who were said to be the strongest and most knowledgeable in all the land. The travelers knew that if they could gain the favor of Blog and his minions, they could achieve their wildest dreams.
-            <br></br>
-            <br></br>
-            As they journeyed through the countryside, the travelers encountered many challenges, from treacherous terrain to fierce beasts. But they persevered, each using their unique skills and abilities to overcome every obstacle in their path.
-            As they neared Blog's castle, they could feel the power emanating from within its walls. They were greeted by React, who welcomed them and led them to Blog's throne room.
-            <br></br>
-            <br></br>
-            There, Blog sat on his throne, flanked by his minions, JavaScript and TypeScript. He listened intently as the travelers explained their quest and their desire to gain his favor.
-            <br></br>
-            <br></br>
-            Blog was impressed by their determination and bravery, and he agreed to help them. He tasked JavaScript and TypeScript with teaching the travelers everything they needed to know about programming and web development, and he enchanted their weapons and tools with powerful spells to aid them on their journey.
-            <br></br>
-            <br></br>
-            The travelers spent many weeks at Blog's castle, learning from his minions and honing their skills. When they were finally ready to set out once again, they knew they were stronger and more capable than ever before.
-            With their new knowledge and enchanted gear, the travelers were able to overcome any obstacle that stood in their way. They forged a path through the wilderness and arrived at their destination, where they achieved their ultimate goal and changed the course of their lives forever.
-            <br></br>
-            <br></br>
-            And so, the tale of the seven travelers and their encounter with Blog and his minions was passed down through the ages as a testament to the power of determination, knowledge, and enchantment.</p>
-          <span>Tags</span> | <span>Story</span>
-        </section>
-
-
-        {/* blog-id-2 */}
-        <section>
-          <h1 id="blog-id-2">Salamander Ashes</h1>
-          <h3>March 6th 2023 | <span>onyx winter</span></h3>
-          <p>Once upon a time, a group of adventurers set out to claim the throne of Most Valuable Pizza.
-            <br></br>
-            <br></br>
-            They had heard that the current ruler, Ticket, had hired a group of mercenaries to defend his claim to the throne.
-            Undeterred, the adventurers marched forward, determined to defeat the Ticket mercenaries and claim the throne for themselves. The battle was fierce, with each side exchanging blows and struggling for control of the battlefield.
-            <br></br>
-            <br></br>
-            Despite their best efforts, the adventurers found themselves unsure if they would be able to emerge victorious. The Ticket mercenaries were well-trained and fiercely loyal to their employer, and they fought with a ferocity that seemed impossible to overcome.
-            As the battle raged on, the adventurers began to fear that they would never be able to claim the throne of Most Valuable Pizza. But they refused to give up, drawing upon their strength and determination to keep fighting.
-            <br></br>
-            <br></br>
-            In the end, the outcome of the battle was uncertain, with neither side gaining a clear advantage. The adventurers retreated to regroup and plan their next move, unsure if they would ever be able to claim the throne they so desperately sought.
-            But they knew that they could never give up, and so they continued to fight, always holding onto the hope that one day they would emerge victorious and claim the throne of Most Valuable Pizza for themselves.
-          </p>
-          <span>Tags</span> | <span>Simple Blog Search </span>
-        </section>
-        {/* blog-id-3 */}
-        <section>
-          <h1 id="blog-id-3">Storm's Fury</h1>
-          <h3>March 22th 2023 | <span>Storm's Fury</span></h3>
-          <p>Once upon a time, the group of adventurers found themselves on a quest to retrieve a magical artifact known as the Eye of the Storm. They had heard that the Eye had the power to control the very elements of nature, and they knew that if they could retrieve it, they could use its power to achieve their greatest desires.
-            <br></br>
-            <br></br>
-            Their journey took them through treacherous mountains and across raging rivers, with danger at every turn. They encountered fierce beasts and battled with ruthless bandits, using all their skills and wits to stay alive.
-            But despite the odds against them, the adventurers pressed on, driven by their desire to claim the Eye of the Storm. They finally reached their destination, a hidden temple deep in the heart of the jungle, where the Eye was said to be kept.
-            <br></br>
-            <br></br>
-            As they made their way through the temple, they encountered traps and puzzles that tested their minds and their courage. But they persevered, finally reaching the chamber where the Eye was kept.
-            <br></br>
-            <br></br>
-            With trembling hands, they reached for the artifact, feeling its power course through their veins. They knew that they had achieved something great, something that would change the course of their lives forever.
-            And so, the adventurers emerged from the temple as heroes, the Eye of the Storm in their possession, ready to face whatever challenges lay ahead.
-          </p>
-          <span>Tags</span> |
-          <span>#story</span>
-          <span>#artifacts</span>
-          <span>#heroes</span>
-        </section>
-        {/* blog-id-4 */}
-        <section>
-          <h1 id="blog-id-4">The Storms Brew</h1>
-          <h3>March 5th 2023 | <span>onyx winter</span></h3>
-          <p>Deep in the mountains, Bruinbrewinbeer was brewing a batch of his famous beer. As he stirred the bubbling concoction, he felt a sense of restlessness. He knew that there were adventures waiting for him out there, and he couldn't resist the call of the unknown.
-            <br></br>
-            <br></br>
-            So, he set out from his mountaintop home, determined to seek out new experiences and meet new people. As he traveled through the wilderness, he encountered iSonic, Nathanjs, and Stephenodea54, each on their own quests.
-            Together, they journeyed across the land, battling monsters and overcoming obstacles that would have deterred lesser adventurers. Along the way, they learned to trust each other and rely on each other's unique strengths.
-            <br></br>
-            <br></br>
-            Their journey eventually led them to a great mountain range, where they found themselves facing four elemental dragons. The dragons were fearsome opponents, each with the power to control one of the elements of nature.
-            At first, the adventurers were unsure if they could defeat the dragons. But they drew upon their courage and their knowledge of the elements, using their wits and their weapons to weaken the dragons one by one.
-            <br></br>
-            <br></br>
-            Finally, as they faced the last dragon, they realized that they needed something more to win the battle. And so, Bruinbrewinbeer pulled out the Storm's Fury, the magical artifact he had been carrying with him all along.
-            <br></br>
-            <br></br>
-            With the Eye of the Storm in their possession, the adventurers were able to harness the power of the elements themselves. They used the artifact to call forth a great storm, the likes of which the dragons had never seen.
-            As the storm raged on, the dragons were weakened and finally defeated, their power absorbed by the adventurers. Bruinbrewinbeer knew that he had found his true calling, as a brewer and an adventurer, and he felt a sense of contentment and joy that he had never known before.
-            <br></br>
-            <br></br>
-            And so, as the adventurers sat around a campfire, drinking the beer that Bruinbrewinbeer had brewed, they knew that they had accomplished something great. They had overcome impossible odds, defeated powerful foes, and emerged stronger and more unified than ever before. They knew that whatever challenges lay ahead, they would face them together, with courage and determination, just like they had on this unforgettable journey.
-          </p>
-          <span>Tags</span> | <span>#brew</span>, <span>#dragons</span>, <span>#fiction</span>
-        </section>
-
-      </div>
-
-      <aside>
-        <ul>
-          <li><a href="#blog-id-1">onyx spring - The tale of Blog</a></li>
-          <li><a href="#blog-id-2">onyx spring - salamander ashes</a></li>
-          <li><a href="#blog-id-3">Storm's Fury</a></li>
-          <li><a href="#blog-id-4">The Storm's Brew</a></li>
-
-        </ul>
-      </aside>
-
-      <footer id="#footer-bar">
-        <ul>
-          <li>Github Repository</li>
-          <li>Team Page</li>
-          <li>Blogs</li>
-          <li>Something else</li>
-        </ul>
-        <p>All Rights Reserved</p>
-      </footer>
-
-
-
-    </div>
+    <Router>
+      <Layout>
+        <Routes>
+          <Route path="/" element={<Blog />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/post" element={<Post />} />
+          <Route path="/metrics" element={<Metrics />} />
+        </Routes>
+      </Layout>
+    </Router>
   );
-}
+};
+
 export default App;

--- a/client/src/Layout.jsx
+++ b/client/src/Layout.jsx
@@ -1,0 +1,63 @@
+import { Link, useLocation } from "react-router-dom";
+
+const Layout = ({ children }) => {
+  const pathname = useLocation().pathname;
+
+  const navbarLinks = [
+    {
+      id: 1,
+      path: "/",
+      label: "Blog",
+    },
+    {
+      id: 2,
+      path: "/about",
+      label: "About",
+    },
+    {
+      id: 3,
+      path: "/post",
+      label: "Post",
+    },
+    {
+      id: 4,
+      path: "/metrics",
+      label: "Metrics",
+    },
+  ];
+
+  return(
+    <>
+      <nav id="nav-bar">
+        <h1><span>&gt; Onyx Sal Blog</span></h1>
+        <ul>
+          { navbarLinks.map(link => (
+            <li
+              key={link.id}
+              style={{
+                // Someone feel free to move this into the .css
+                fontWeight: link.path === pathname ? 700 : 400
+              }}
+            >
+              <Link to={link.path}>{link.label}</Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {children}
+
+      <footer id="#footer-bar">
+        <ul>
+          <li>Github Repository</li>
+          <li>Team Page</li>
+          <li>Blogs</li>
+          <li>Something else</li>
+        </ul>
+        <p>All Rights Reserved</p>
+      </footer>
+    </>
+  );
+};
+
+export default Layout;

--- a/client/src/pages/About.jsx
+++ b/client/src/pages/About.jsx
@@ -1,0 +1,3 @@
+const About = () => <div>Hello from About Page!</div>
+
+export default About;

--- a/client/src/pages/Blog.jsx
+++ b/client/src/pages/Blog.jsx
@@ -1,0 +1,119 @@
+const Blog = () => {
+  return(
+    <>
+      <div id="section-and-aside">
+      {/* this sections holds our blog poast with everything inside of it 
+          <span> is what changes the font color
+      */}
+      {/* blog-id-1 */}
+        <section>
+          <h1 id="blog-id-1">This is the first post for the onyx crew</h1>
+          <h3>March 31st 2023 | <span>onyx spring</span></h3>
+          <p>Once upon a time, in a faraway land, there were seven travelers who set out on a quest to meet the powerful enchanter named Blog. These seven travelers were named Bruinbrewinbeer, DKKKKKKKK, iSonic, Jc, Julian_P, Nathanjs the King, and Stephenodea54.
+            The travelers had heard tales of Blog's incredible powers of enchantment and his minions, React, JavaScript, and TypeScript, who were said to be the strongest and most knowledgeable in all the land. The travelers knew that if they could gain the favor of Blog and his minions, they could achieve their wildest dreams.
+            <br></br>
+            <br></br>
+            As they journeyed through the countryside, the travelers encountered many challenges, from treacherous terrain to fierce beasts. But they persevered, each using their unique skills and abilities to overcome every obstacle in their path.
+            As they neared Blog's castle, they could feel the power emanating from within its walls. They were greeted by React, who welcomed them and led them to Blog's throne room.
+            <br></br>
+            <br></br>
+            There, Blog sat on his throne, flanked by his minions, JavaScript and TypeScript. He listened intently as the travelers explained their quest and their desire to gain his favor.
+            <br></br>
+            <br></br>
+            Blog was impressed by their determination and bravery, and he agreed to help them. He tasked JavaScript and TypeScript with teaching the travelers everything they needed to know about programming and web development, and he enchanted their weapons and tools with powerful spells to aid them on their journey.
+            <br></br>
+            <br></br>
+            The travelers spent many weeks at Blog's castle, learning from his minions and honing their skills. When they were finally ready to set out once again, they knew they were stronger and more capable than ever before.
+            With their new knowledge and enchanted gear, the travelers were able to overcome any obstacle that stood in their way. They forged a path through the wilderness and arrived at their destination, where they achieved their ultimate goal and changed the course of their lives forever.
+            <br></br>
+            <br></br>
+            And so, the tale of the seven travelers and their encounter with Blog and his minions was passed down through the ages as a testament to the power of determination, knowledge, and enchantment.</p>
+          <span>Tags</span> | <span>Story</span>
+        </section>
+
+
+        {/* blog-id-2 */}
+        <section>
+          <h1 id="blog-id-2">Salamander Ashes</h1>
+          <h3>March 6th 2023 | <span>onyx winter</span></h3>
+          <p>Once upon a time, a group of adventurers set out to claim the throne of Most Valuable Pizza.
+            <br></br>
+            <br></br>
+            They had heard that the current ruler, Ticket, had hired a group of mercenaries to defend his claim to the throne.
+            Undeterred, the adventurers marched forward, determined to defeat the Ticket mercenaries and claim the throne for themselves. The battle was fierce, with each side exchanging blows and struggling for control of the battlefield.
+            <br></br>
+            <br></br>
+            Despite their best efforts, the adventurers found themselves unsure if they would be able to emerge victorious. The Ticket mercenaries were well-trained and fiercely loyal to their employer, and they fought with a ferocity that seemed impossible to overcome.
+            As the battle raged on, the adventurers began to fear that they would never be able to claim the throne of Most Valuable Pizza. But they refused to give up, drawing upon their strength and determination to keep fighting.
+            <br></br>
+            <br></br>
+            In the end, the outcome of the battle was uncertain, with neither side gaining a clear advantage. The adventurers retreated to regroup and plan their next move, unsure if they would ever be able to claim the throne they so desperately sought.
+            But they knew that they could never give up, and so they continued to fight, always holding onto the hope that one day they would emerge victorious and claim the throne of Most Valuable Pizza for themselves.
+          </p>
+          <span>Tags</span> | <span>Simple Blog Search </span>
+        </section>
+        {/* blog-id-3 */}
+        <section>
+          <h1 id="blog-id-3">Storm's Fury</h1>
+          <h3>March 22th 2023 | <span>Storm's Fury</span></h3>
+          <p>Once upon a time, the group of adventurers found themselves on a quest to retrieve a magical artifact known as the Eye of the Storm. They had heard that the Eye had the power to control the very elements of nature, and they knew that if they could retrieve it, they could use its power to achieve their greatest desires.
+            <br></br>
+            <br></br>
+            Their journey took them through treacherous mountains and across raging rivers, with danger at every turn. They encountered fierce beasts and battled with ruthless bandits, using all their skills and wits to stay alive.
+            But despite the odds against them, the adventurers pressed on, driven by their desire to claim the Eye of the Storm. They finally reached their destination, a hidden temple deep in the heart of the jungle, where the Eye was said to be kept.
+            <br></br>
+            <br></br>
+            As they made their way through the temple, they encountered traps and puzzles that tested their minds and their courage. But they persevered, finally reaching the chamber where the Eye was kept.
+            <br></br>
+            <br></br>
+            With trembling hands, they reached for the artifact, feeling its power course through their veins. They knew that they had achieved something great, something that would change the course of their lives forever.
+            And so, the adventurers emerged from the temple as heroes, the Eye of the Storm in their possession, ready to face whatever challenges lay ahead.
+          </p>
+          <span>Tags</span> |
+          <span>#story</span>
+          <span>#artifacts</span>
+          <span>#heroes</span>
+        </section>
+        {/* blog-id-4 */}
+        <section>
+          <h1 id="blog-id-4">The Storms Brew</h1>
+          <h3>March 5th 2023 | <span>onyx winter</span></h3>
+          <p>Deep in the mountains, Bruinbrewinbeer was brewing a batch of his famous beer. As he stirred the bubbling concoction, he felt a sense of restlessness. He knew that there were adventures waiting for him out there, and he couldn't resist the call of the unknown.
+            <br></br>
+            <br></br>
+            So, he set out from his mountaintop home, determined to seek out new experiences and meet new people. As he traveled through the wilderness, he encountered iSonic, Nathanjs, and Stephenodea54, each on their own quests.
+            Together, they journeyed across the land, battling monsters and overcoming obstacles that would have deterred lesser adventurers. Along the way, they learned to trust each other and rely on each other's unique strengths.
+            <br></br>
+            <br></br>
+            Their journey eventually led them to a great mountain range, where they found themselves facing four elemental dragons. The dragons were fearsome opponents, each with the power to control one of the elements of nature.
+            At first, the adventurers were unsure if they could defeat the dragons. But they drew upon their courage and their knowledge of the elements, using their wits and their weapons to weaken the dragons one by one.
+            <br></br>
+            <br></br>
+            Finally, as they faced the last dragon, they realized that they needed something more to win the battle. And so, Bruinbrewinbeer pulled out the Storm's Fury, the magical artifact he had been carrying with him all along.
+            <br></br>
+            <br></br>
+            With the Eye of the Storm in their possession, the adventurers were able to harness the power of the elements themselves. They used the artifact to call forth a great storm, the likes of which the dragons had never seen.
+            As the storm raged on, the dragons were weakened and finally defeated, their power absorbed by the adventurers. Bruinbrewinbeer knew that he had found his true calling, as a brewer and an adventurer, and he felt a sense of contentment and joy that he had never known before.
+            <br></br>
+            <br></br>
+            And so, as the adventurers sat around a campfire, drinking the beer that Bruinbrewinbeer had brewed, they knew that they had accomplished something great. They had overcome impossible odds, defeated powerful foes, and emerged stronger and more unified than ever before. They knew that whatever challenges lay ahead, they would face them together, with courage and determination, just like they had on this unforgettable journey.
+          </p>
+          <span>Tags</span> | <span>#brew</span>, <span>#dragons</span>, <span>#fiction</span>
+        </section>
+
+      </div>
+
+      <aside>
+        <ul>
+          <li><a href="#blog-id-1">onyx spring - The tale of Blog</a></li>
+          <li><a href="#blog-id-2">onyx spring - salamander ashes</a></li>
+          <li><a href="#blog-id-3">Storm's Fury</a></li>
+          <li><a href="#blog-id-4">The Storm's Brew</a></li>
+
+        </ul>
+      </aside>
+    </>
+  );
+};
+
+export default Blog;

--- a/client/src/pages/Metrics.jsx
+++ b/client/src/pages/Metrics.jsx
@@ -1,0 +1,3 @@
+const Metrics = () => <div>Hello from Metrics Page!</div>
+
+export default Metrics;

--- a/client/src/pages/Post.jsx
+++ b/client/src/pages/Post.jsx
@@ -1,0 +1,3 @@
+const Post = () => <div>Hello from Posts Page!</div>
+
+export default Post;


### PR DESCRIPTION
Added React Router as a dependency to handle the routing for the app. Each link in the navbar now points to a specific page component, which have been moved to the `/pages` directory.

There's also conditional rendering for the links. Whichever page is currently "active", the corresponding link in the navbar will be bold. I hate writing with plain CSS, so I just used inline styling for the conditional stuff.

FYI, I have to use codespaces when contributing to this repo, so my commit history isn't as clean as I would like it to be.