### PR TITLE
Add Comments Table and Left Join Author Information

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -8,20 +8,31 @@ generator client {
 datasource db {
   provider     = "mysql"
   url          = env("DATABASE_URL")
-  relationMode = "prisma" // Need this for foreign key contrai
+  relationMode = "prisma" // Need this for foreign key contraints
 }
 
 model Post {
-  id        Int      @id @default(autoincrement())
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  title     String   
-  author    User     @relation(fields: [authorId], references: [id])
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  title     String
+  author    User      @relation(fields: [authorId], references: [id])
   authorId  Int
-  content   String   @db.Text
-  tags      Tag[]    @relation("TagsAndPosts")
+  content   String    @db.Text
+  tags      Tag[]     @relation("TagsAndPosts")
+  comments  Comment[]
 
   @@index(authorId)
+}
+
+model Comment {
+  id      Int    @id @default(autoincrement())
+  author  String
+  content String @db.Text
+  post    Post   @relation(fields: [postId], references: [id])
+  postId  Int
+
+  @@index(postId)
 }
 
 model Tag {

--- a/server/src/routes/posts.ts
+++ b/server/src/routes/posts.ts
@@ -2,14 +2,21 @@ import { Prisma } from "@prisma/client";
 import express from "express";
 import prisma from "../prisma.js";
 
-// TODO: Put array methods into their own module
-
 const router = express.Router();
 
 // Get all blog posts
 router.get("/posts", async (_req, res) => {
   const posts = await prisma.post.findMany({
-    include: { tags: true },
+    select: {
+      id: true,
+      createdAt: true,
+      updatedAt: true,
+      title: true,
+      content: true,
+      tags: true,
+      author: true,
+      comments: true,
+    },
   });
 
   res.json(posts);
@@ -22,7 +29,16 @@ router.get("/posts/:id", async (req, res) => {
 
   const post = await prisma.post.findUnique({
     where: { id: idInt },
-    include: { tags: true },
+    select: {
+      id: true,
+      createdAt: true,
+      updatedAt: true,
+      title: true,
+      content: true,
+      tags: true,
+      author: true,
+      comments: true,
+    },
   });
 
   res.json(post);
@@ -31,10 +47,6 @@ router.get("/posts/:id", async (req, res) => {
 // Create a blog post
 router.post("/posts", async (req, res) => {
   const { title, content, authorName, tags } = req.body;
-
-  // const tagsData = tags.map((tag: Prisma.TagCreateInput) => {
-  //   return { name: tag.name }
-  // });
 
   const post = await prisma.post.create({
     data: {

--- a/server/src/routes/tags.ts
+++ b/server/src/routes/tags.ts
@@ -1,4 +1,3 @@
-import { Prisma } from "@prisma/client";
 import express from "express";
 import prisma from "../prisma.js";
 


### PR DESCRIPTION
- Added comments table so that site visitors have the ability to leave comments on each blog post.
  - Didn't plan on this being its own table, but Prisma does not support native Scalar lists if the engine is MySQL (another reason why PostGres is better lol).
  - Article related to above: https://github.com/prisma/prisma/blob/ba74c81fdbc9e6405946fdc6f9d42d103d008dc2/docs/upgrade-guides/upgrading-to-preview019.md
- Left joined the author information so we can use the author name when dynamically displaying the blog posts.

Closes #44 
Closes #46 